### PR TITLE
Hotfix/issue/6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *.backup
 *.bbl
 *.blg
+*.dat

--- a/velcat.sh
+++ b/velcat.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+#
+# velcat.sh (Shell Script)
+# 
+# Objetivo: Organizar informações sobre velocidade dos CMP's em um único arquivo.
+# 
+# Site: https://dirack.github.io
+# 
+# Versão 1.0
+# 
+# Programador: Rodolfo A C Neves (Dirack) 26/03/2020
+# 
+# Email: rodolfo_profissional@hotmail.com
+# 
+# Licença: GPL-3.0 <https://www.gnu.org/licenses/gpl-3.0.txt>.
+
+# Se o usuário não passar um nome
+# de arquivo, utilize vela.dat
+VELAN_FILE="velan.dat"
+[ -z "$1" ] || {
+	VELAN_FILE="$1"
+}
+
+# Buscar CMP's na pasta atual
+CMPS=$(ls cmp*.dat)
+
+echo "cdp=$(echo $CMPS | sed 's/.dat//g;s/cmp//g;s/ /,/g') \\" > "$VELAN_FILE"
+
+for i in $CMPS
+do
+	FILE="$i"
+
+	grep "tnmo" -A1 "$FILE" >> "$VELAN_FILE"
+done


### PR DESCRIPTION
:outbox_tray: **Pull Request**

**Descrição**

@sanmurilo,
Para corrigir o Bug, troquei a utilização do comando sed pelo grep na impressão das duas primeiras linhas de cada arquivo cmp\*.dat para o arquivo velan.dat

Resolve #6 

**Tipo da modificação**

- [x] Correção de Bug (modificação que corrige uma problema)
- [ ] Nova feature (modificação que adiciona uma funcionalidade)
- [ ] Atualização de documentação
- [ ] Outros (_Descrever aqui_)

**Adicione imagens abaixo e o contexto se necessário**

Duas novas funcionalidades foram adicionadas ao script velcat.sh:

Para tornar o programa mais geral, o programa lista da pasta atual todos os arquivos que casam com a regex **cmp\*.dat** na variável CMPS e percorre estes arquivos em loop, imprimindo as duas primeiras linhas para o arquivo de saída.

Por padrão, o programa utiliza o nome do arquivo de saída como 'velan.dat', porém este nome pode ser alterado passando um nome de arquivo como argumento ao programa, exemplo:

```sh
~$ ./velcat.sh <nomeArquivo.dat>
```