### PR TITLE
Reconfigura o ambiente de testes do travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,5 @@ services:
   - docker
 
 script:
-  - docker run dirack/ambienteprosu:1.1 bash -c "make test"
+  - docker run -t -v $PWD:/proSU dirack/ambienteprosu:1.2 bash -c 'CWPROOT=$HOME && PATH=$PATH:$CWPROOT/bin && make test'
 


### PR DESCRIPTION
:outbox_tray: **Pull Request**

**Descrição**

O Travis estava ignorando os novos testes da proSU, pois utilizava uma
imagem com a biblioteca desatualizada. Agora o container é gerado com
um volume /proSU que contém a versão atual da biblioteca e relaiza os
testes neste volume.

O comando executado no container também foi corrigido, pois o caractere
'"' (aspas duplas) permite a expansão de variáveis de fora do container
para dentro do container, fazendo com que os programas do SU instalados
no container não pudessem ser encontrados

**Tipo da modificação**

- [x] Correção de Bug (modificação que corrige uma problema)
- [ ] Nova feature (modificação que adiciona uma funcionalidade)
- [ ] Atualização de documentação
- [ ] Outros (_Descrever aqui_)
