### PR TITLE
Teste gerar imagem eps de modelo Resolve #12

### DIFF
--- a/TDD/geomodel_tdd.sh
+++ b/TDD/geomodel_tdd.sh
@@ -26,9 +26,10 @@ DIR=".."
 # Criar novo modelo itf
 TMP=$(mktemp -u tmp_XXXX.itf)
 TMPBIN=$(echo $TMP | cut -d"." -f1)
+TMPEPS="${TMPBIN}.eps"
 TMPBIN="${TMPBIN}.bin"
 
-trap "rm $TMP $TMPBIN" err exit
+trap "rm $TMP $TMPBIN $TMPEPS" err exit
 
 # Criar modelo de testes e adicionar 7 interfaces
 $DIR/interfaceBuilder -c "$TMP" 0 12 0 3.5 
@@ -49,3 +50,7 @@ done
 $DIR/geomodel -m $TMPBIN $TMP
 
 error "$?" "0" "1" "Gerar modelo..."
+
+$DIR/geomodel -i $TMPBIN $TMP
+
+error "$?" "0" "2" "Gerar imagem eps do modelo..."


### PR DESCRIPTION
:outbox_tray: **Pull Request**

**Descrição**

Teste automatizado da opção -i do programa geomodel.
Esta gera uma imagem eps de um modelo das velocidades em subsuperfície.

O programa geomodel é uma interface que roda internamente o programa spsplot do pacote
SU. E que gera a imagem eps a partir de um modelo em arquivo binário. Este arquivo binário 
 é gerado pelo programa trimodel, também do pacote SU, e chamado pela interface geomodel
com a opção -m.

Resolve #12

**Tipo da modificação**

- [ ] Correção de Bug (modificação que corrige uma problema)
- [x] Nova feature (modificação que adiciona uma funcionalidade)
- [ ] Atualização de documentação
- [ ] Outros (_Descrever aqui_)

**Adicione imagens abaixo e o contexto se necessário**

O resumo do fluxo de processamento para gerar o modelo e a imagem eps a partir de um arquivo de interfaces do programa interfaceBuilder:

1. Gerar modelo em arquivo binário.

```sh
~$ ./geomodel modelo.bin modelo.itf 
```

2. Gerar imagem eps do binário.

```sh
~$ ./geomodel modelo.bin modelo.itf
```

O comando acima gera um arquivo 'modelo.eps' com a imagem eps.